### PR TITLE
Add 1hour timeout to Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
     options {
         timestamps()
         buildDiscarder(logRotator(numToKeepStr: "10")) // keep only last 10 builds
+        timeout(time: 1, unit: 'HOURS')
     }
 
     environment {


### PR DESCRIPTION
## Description

Abort the build if it exceeds 1 hour.

## Checklist

- [ ] Acceptance Criteria met
- [x] Commit messages are meaningful
- [ ] Manually tested
- [x] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [ ] If your pull request depends on any other, please link them in the description
- [x] main branch is passing/green on CI
- [ ] Add/update any relevant documentation
