### PR TITLE
Update ECR login command to use non-deprecated get-login-password

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -164,8 +164,7 @@ Map<String,String> collectTfOutputs(String component) {
 }
 
 int ecrLogin(String aws_region) {
-    String ecrCommand = "aws ecr get-login --region ${aws_region}"
-    String dockerLogin = sh (label: "Getting Docker login from ECR", script: ecrCommand, returnStdout: true).replace("-e none","") // some parameters that AWS provides and docker does not recognize
+    String dockerLogin = "aws ecr get-login-password --region ${aws_region} | docker login -u AWS --password-stdin \"https://\$(aws sts get-caller-identity --query 'Account' --output text).dkr.ecr.${aws_region}.amazonaws.com\""
     return sh(label: "Logging in with Docker", script: dockerLogin, returnStatus: true)
 }
 


### PR DESCRIPTION
## Description

get-login is deprecated

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [ ] Acceptance Criteria met
- [x] Commit messages are meaningful
- [ ] Manually tested
- [x] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [ ] If your pull request depends on any other, please link them in the description
- [x] main branch is passing/green on CI
- [ ] Add/update any relevant documentation