### PR TITLE
NIAD-3307: Changed the java version, mongodb version, and removed the memory limit.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle --no-daemon -b build.gradle bootJar -i --stacktrace
 
-FROM adoptopenjdk/openjdk11-openj9:jre
+FROM amazoncorretto:11.0.26
 
 EXPOSE 8080
 
@@ -19,4 +19,4 @@ RUN mkdir /app
 
 COPY --from=build /home/gradle/src/build/libs/*.jar /app/integration-adaptor-lab-results.jar
 
-ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/app/integration-adaptor-lab-results.jar"]
+ENTRYPOINT ["java", "-XX:+UnlockExperimentalVMOptions", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/app/integration-adaptor-lab-results.jar"]

--- a/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/container/MongoDbContainer.java
+++ b/src/intTest/java/uk/nhs/digital/nhsconnect/lab/results/container/MongoDbContainer.java
@@ -7,7 +7,7 @@ import org.testcontainers.containers.GenericContainer;
 public final class MongoDbContainer extends GenericContainer<MongoDbContainer> {
 
     private static final int MONGODB_PORT = 27017;
-    private static final String DEFAULT_IMAGE_AND_TAG = "mongo:3.2.4";
+    private static final String DEFAULT_IMAGE_AND_TAG = "mongo:8.0.5";
     private static MongoDbContainer container;
 
     private MongoDbContainer() {


### PR DESCRIPTION
## Description

Changed the version of java and mongoDB. The former so that everything could be run on M1 Macs correctly, the latter because it was deprecated.

## Jira Ticket

3307

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [ ] Acceptance Criteria met
- [ ] Commit messages are meaningful
- [ ] Manually tested
- [ ] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [ ] If your pull request depends on any other, please link them in the description
- [ ] main branch is passing/green on CI
- [ ] Add/update any relevant documentation
