### PR TITLE
NIAD-3333: NHS Best Practice for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,13 @@ jobs:
   generate-build-id:
     name: "Generate Build Id"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       build-id: ${{ steps.generate.outputs.buildId }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - id: generate
         working-directory: ./scripts
@@ -40,6 +42,8 @@ jobs:
     name: "Tests"
     needs: [ generate-build-id ]
     uses: ./.github/workflows/test.yml
+    permissions:
+      contents: read
     with:
       name: Lab Results Adaptor
       path: ./
@@ -49,6 +53,9 @@ jobs:
   publish-docker-images:
     name: "Publish docker images to ECR"
     needs: [ generate-build-id, tests ]
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         config:
@@ -64,16 +71,17 @@ jobs:
     name: "Create Build ID Comment"
     needs: [ generate-build-id, publish-docker-images ]
     continue-on-error: true
-    permissions: write-all
+    permissions:
+      pull-requests: write
     runs-on: [ ubuntu-latest ]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Comment PR
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: |
             Images built and published to ECR using a Build Id of ${{ needs.generate-build-id.outputs.build-id }}
-          comment_tag: images-built
+          comment-tag: images-built
           mode: upsert
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: gp2gp_github_action_build_workflow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,14 @@ jobs:
   checkstyle:
     name: ${{ inputs.name }} Checkstyle
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #4.7.1
         with:
           java-version: 21
           distribution: 'temurin'
@@ -37,7 +39,7 @@ jobs:
           cp -r ./${{ inputs.path }}/build/reports ./artifacts
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         if: always()
         with:
           name: '${{ inputs.name }} Checkstyle Report'
@@ -50,12 +52,14 @@ jobs:
   spotbugs:
     name: ${{ inputs.name }} Spotbugs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #4.7.1
         with:
           java-version: 21
           distribution: 'temurin'
@@ -71,7 +75,7 @@ jobs:
           cp -r ./${{ inputs.path }}/build/reports ./artifacts
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         if: always()
         with:
           name: '${{ inputs.name }} Spotbugs Report'
@@ -85,12 +89,14 @@ jobs:
     name: ${{ inputs.name }} Unit Tests
     needs: [ checkstyle, spotbugs ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #4.7.1
         with:
           java-version: 21
           distribution: 'temurin'
@@ -106,7 +112,7 @@ jobs:
           cp -r ./${{ inputs.path }}/build/reports/tests/test ./artifacts
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         if: always()
         with:
           name: '${{ inputs.name }} Unit Test Report'
@@ -115,7 +121,7 @@ jobs:
 
       - name: Test Job Summary
         if: always()
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 #v2.4.0
         with:
           paths: "${{ inputs.path }}/build/test-results/test/TEST-*.xml"
 
@@ -126,12 +132,14 @@ jobs:
     name: ${{ inputs.name }} Integration Tests
     needs: [ checkstyle, spotbugs ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # 4.7.1
         with:
           java-version: 21
           distribution: 'temurin'
@@ -155,7 +163,7 @@ jobs:
           cp -r ./${{ inputs.path }}/build/reports/tests/integrationTest ./artifacts
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         if: always()
         with:
           name: '${{ inputs.name }} Integration Test Report'
@@ -174,7 +182,7 @@ jobs:
 
       - name: Test Job Summary
         if: always()
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 #v2.4.0
         with:
           paths: "${{ inputs.path }}/build/test-results/integrationTest/TEST-*.xml"
 


### PR DESCRIPTION
## Description

* Restrict permissions per job to ensure that only the least required permissions are granted in `build` workflow.
* Use SHAs for GitHub Actions `actions` instead of versions to ensure we have control over exactly which version is being used in `build` workflow.

## Jira Ticket

[NIAD-3333](https://nhse-dsic.atlassian.net/browse/NIAD-3333)

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Acceptance Criteria met
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] Self-reviewed your code
- [x] main branch is passing/green on CI
