### PR TITLE
NIAD-3354: Update to use gradle 9.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
 
   publish-docker-images:
     name: "Publish docker images to ECR"
-    needs: [ generate-build-id ]
+    needs: [ generate-build-id, tests ]
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
 
   publish-docker-images:
     name: "Publish docker images to ECR"
-    needs: [ generate-build-id, tests ]
+    needs: [ generate-build-id ]
     permissions:
       id-token: write
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM gradle:jdk21 AS build
 COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN gradle --no-daemon -b bootJar -i --stacktrace
+RUN gradle --no-daemon bootJar -i --stacktrace
 
 FROM amazoncorretto:21-alpine
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ RUN mkdir -p /home/gradle/cache_home
 ENV GRADLE_USER_HOME /home/gradle/cache_home
 COPY build.gradle /home/gradle/src/
 WORKDIR /home/gradle/src
-RUN gradle -b build.gradle clean build -i --stacktrace
+RUN gradle clean build -i --stacktrace
 
 FROM gradle:jdk21 AS build
 COPY --from=cache /home/gradle/cache_home /home/gradle/.gradle
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN gradle --no-daemon -b build.gradle bootJar -i --stacktrace
+RUN gradle --no-daemon -b bootJar -i --stacktrace
 
 FROM amazoncorretto:21-alpine
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,9 @@ plugins {
 
 group = 'uk.nhs.digital.nhsconnect'
 version = '0.0.5-SNAPSHOT'
-sourceCompatibility = '21'
+//sourceCompatibility = '21'
 
-mainClassName = 'uk.nhs.digital.nhsconnect.lab.results.IntegrationAdapterLabResultsApplication'
+//mainClassName = 'uk.nhs.digital.nhsconnect.lab.results.IntegrationAdapterLabResultsApplication'
 
 sourceSets {
 	intTest {
@@ -111,10 +111,4 @@ spotbugs {
 
 checkstyle {
 	configFile = file("${rootDir}/config/checkstyle/checkstyle.xml")
-}
-
-idea {
-	module {
-		testSourceDirs += file('src/intTest/java')
-	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,16 @@ plugins {
 
 group = 'uk.nhs.digital.nhsconnect'
 version = '0.0.5-SNAPSHOT'
-//sourceCompatibility = '21'
 
-//mainClassName = 'uk.nhs.digital.nhsconnect.lab.results.IntegrationAdapterLabResultsApplication'
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+application {
+    mainClass = 'uk.nhs.digital.nhsconnect.lab.results.IntegrationAdapterLabResultsApplication'
+}
 
 sourceSets {
 	intTest {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/TemplateUtilsTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/TemplateUtilsTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.nhs.digital.nhsconnect.lab.results.utils.TemplateUtils.loadTemplate;
 import static uk.nhs.digital.nhsconnect.lab.results.utils.TemplateUtils.fillTemplate;
 
-class TemplateUtilsTest {
+final class TemplateUtilsTest {
 
     private static final String TEMPLATE_FILLED_WITH_VALUES_PATH =
         "src/test/resources/templates/filled_template_with_value.txt";

--- a/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/TemplateUtilsTest.java
+++ b/src/test/java/uk/nhs/digital/nhsconnect/lab/results/utils/TemplateUtilsTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.nhs.digital.nhsconnect.lab.results.utils.TemplateUtils.loadTemplate;
 import static uk.nhs.digital.nhsconnect.lab.results.utils.TemplateUtils.fillTemplate;
 
-final class TemplateUtilsTest {
+class TemplateUtilsTest {
 
     private static final String TEMPLATE_FILLED_WITH_VALUES_PATH =
         "src/test/resources/templates/filled_template_with_value.txt";
@@ -73,7 +73,7 @@ final class TemplateUtilsTest {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    private class TemplateTestClass {
+    private final class TemplateTestClass {
 
         private String templateValue;
     }


### PR DESCRIPTION

## Description

* Update to use gradle 9.0.0

Microsoft have updated the GitHub test runners to use Gradle 9.0.  As the lab adaptor was using gradle files formats and running the build scripts without using a gradle wrapper, it was easier to update the current way of working to use gradle 9 instead.

## Jira Ticket

NIAD-3354

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [x] Acceptance Criteria met
- [x] Commit messages are meaningful
- [x] Manually tested
- [x] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [x] main branch is passing/green on CI
