### PR TITLE
niad-3448: add 7 day cooldown to gradle package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Description

Added a 7 day cooldown to gradle updates in dependabot.yml

## Jira Ticket

(http://nhse-dsic.atlassian.net/jira/software/c/projects/NIAD/boards/68?selectedIssue=NIAD-3448&visitedUserSeg=true)

## Checklist

These are items (excluding GitHub Checks) which should be confirmed before a branch is ready to merge.

- [ ] Acceptance Criteria met
- [x] Commit messages are meaningful
- [x] Self-reviewed your code
- [ ] Code reviewed from two other developers
- [ ] main branch is passing/green on CI
